### PR TITLE
feat: update main name

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "piou"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
Improves how program names are displayed in usage messages by implementing better handling for module execution scenarios. 
The change addresses the issue where running a module with python -m module_name would show __main__.py instead of the actual module name in help text.