### PR TITLE
fix: reflow multi-line command description prose in help output

### DIFF
--- a/piou/formatter/rich_formatter.py
+++ b/piou/formatter/rich_formatter.py
@@ -132,7 +132,7 @@ class RichFormatter(Formatter):
                 self._console.print(
                     pad(
                         Markdown(
-                            "  \n".join(description.split("\n")),
+                            description,
                             code_theme=self.code_theme,
                         )
                     ),

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -8,14 +8,24 @@ from piou.utils import Password, Secret
 @pytest.mark.parametrize(
     "options, input, expected",
     [
-        ({"use_markdown": True}, "**test**", "\nDESCRIPTION\n test"),
-        (
+        pytest.param({"use_markdown": True}, "**test**", "\nDESCRIPTION\n test", id="markdown_bold"),
+        pytest.param(
             {"use_markdown": True},
             "[bold]test[/bold]",
             "\nDESCRIPTION\n [bold]test[/bold]",
+            id="markdown_rich_markup_kept",
         ),
-        ({"use_markdown": False}, "**test**", "\nDESCRIPTION\n **test**"),
-        ({"use_markdown": False}, "[bold]test[/bold]", "\nDESCRIPTION\n test"),
+        pytest.param({"use_markdown": False}, "**test**", "\nDESCRIPTION\n **test**", id="no_markdown_bold"),
+        pytest.param(
+            {"use_markdown": False}, "[bold]test[/bold]", "\nDESCRIPTION\n test", id="no_markdown_rich_markup"
+        ),
+        pytest.param(
+            {"use_markdown": True},
+            # A single newline reflows prose; a blank line stays a paragraph break.
+            "First sentence of the paragraph.\nSecond sentence on a new source line.\n\nA separate paragraph.",
+            "\nDESCRIPTION\n First sentence of the paragraph. Second sentence on a new source line.\n\n A separate paragraph.",
+            id="markdown_multiline_reflow",
+        ),
     ],
 )
 def test_rich_formatting_options(options, input, expected, capsys):
@@ -24,24 +34,8 @@ def test_rich_formatting_options(options, input, expected, capsys):
 
     formatter = RichFormatter(**options)
     formatter._print_description(Command("", lambda x: ..., description=input))
-    assert capsys.readouterr().out.rstrip() == expected
-
-
-def test_rich_multiline_description_reflows(capsys):
-    """A single newline reflows prose; a blank line stays a paragraph break."""
-    from piou.formatter import RichFormatter
-    from piou.command import Command
-
-    description = "First sentence of the paragraph.\nSecond sentence on a new source line.\n\nA separate paragraph."
-    RichFormatter(use_markdown=True)._print_description(Command("", lambda x: ..., description=description))
-    lines = [line.rstrip() for line in capsys.readouterr().out.splitlines()]
-    assert lines == [
-        "",
-        "DESCRIPTION",
-        " First sentence of the paragraph. Second sentence on a new source line.",
-        "",
-        " A separate paragraph.",
-    ]
+    output = "\n".join(line.rstrip() for line in capsys.readouterr().out.splitlines())
+    assert output.rstrip() == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -27,6 +27,23 @@ def test_rich_formatting_options(options, input, expected, capsys):
     assert capsys.readouterr().out.rstrip() == expected
 
 
+def test_rich_multiline_description_reflows(capsys):
+    """A single newline reflows prose; a blank line stays a paragraph break."""
+    from piou.formatter import RichFormatter
+    from piou.command import Command
+
+    description = "First sentence of the paragraph.\nSecond sentence on a new source line.\n\nA separate paragraph."
+    RichFormatter(use_markdown=True)._print_description(Command("", lambda x: ..., description=description))
+    lines = [line.rstrip() for line in capsys.readouterr().out.splitlines()]
+    assert lines == [
+        "",
+        "DESCRIPTION",
+        " First sentence of the paragraph. Second sentence on a new source line.",
+        "",
+        " A separate paragraph.",
+    ]
+
+
 @pytest.mark.parametrize(
     "value, show_first, show_last, expected",
     [


### PR DESCRIPTION
## What

`RichFormatter._print_description()` joined every description line with a Markdown hard break (`"  \n"`), so a wrapped docstring reproduced its source line breaks verbatim in `-h` output — leaving orphan fragments like `and TLS cert` and `multi-project` on their own lines.

This passes the description verbatim to `Markdown` instead.

## Effect

Prose within a paragraph now reflows to terminal width; blank lines remain paragraph breaks.

**Before**
```
DESCRIPTION
 Credentials are read from the SCW profile. The PG backend connection string
 and TLS cert
 are fetched from Scaleway Secret Manager — pass --secret-id explicitly for
 multi-project
 setups, or let it fall back to parsing provisioning/scripts/setup-backend.sh.
```

**After**
```
DESCRIPTION
 Credentials are read from the SCW profile. The PG backend connection string
 and TLS cert are fetched from Scaleway Secret Manager — pass --secret-id
 explicitly for multi-project setups, or let it fall back to parsing
 provisioning/scripts/setup-backend.sh.
```

## Trade-off

A single `\n` in a description no longer forces a line break — use a blank line, two trailing spaces, or a Markdown list/code block for intentional breaks (standard Markdown semantics).

All 66 formatter tests pass.