### PR TITLE
fix: accumulate repeated list-option flags instead of overwriting

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -127,6 +127,9 @@ numbers: list[int] = Option([], "--nums")
 
 Usage: `command --files a.txt b.txt c.txt`
 
+Repeating the flag accumulates values, so `command --files a.txt --files b.txt` is
+equivalent to `command --files a.txt b.txt`. (Repeated non-list flags keep the last value.)
+
 ## Choices
 
 ### Static Choices

--- a/piou/utils.py
+++ b/piou/utils.py
@@ -589,12 +589,17 @@ def get_cmd_args(
             keyword_params[_arg] = True
         else:
             # Value parameters: Take the next argument as their value and mark that position to be skipped
-            keyword_params[_arg] = (
+            value = (
                 cmd_split[i + 1]
                 if i + 1 < len(cmd_split)
                 # In case of "store_true"
                 else True
             )
+            previous = keyword_params.get(_arg)
+            # Repeated list flags accumulate (--foo 1 --foo 2 == --foo 1 2)
+            if _is_list_type(curr_type) and isinstance(previous, str) and isinstance(value, str):
+                value = f"{previous} {value}"
+            keyword_params[_arg] = value
             skip_position = i + 1
 
     return positional_args, keyword_params

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -436,6 +436,20 @@ def test_invalid_validate_value(data_type, value, expected, expected_str):
             {"--foo": "1 2 3", "--bar": "baz"},
             id="list_flag_then_single_flag_then_positional",
         ),
+        pytest.param(
+            "--foo 1 --foo 2 3",
+            {"foo": list[int]},
+            [],
+            {"--foo": "1 2 3"},
+            id="repeated_list_flag_accumulates",
+        ),
+        pytest.param(
+            "--foo a --foo b",
+            {"foo": str},
+            [],
+            {"--foo": "b"},
+            id="repeated_scalar_flag_keeps_last",
+        ),
     ],
 )
 def test_get_cmd_args(input_str, types, expected_pos_args, expected_key_args):

--- a/uv.lock
+++ b/uv.lock
@@ -1343,7 +1343,7 @@ wheels = [
 
 [[package]]
 name = "piou"
-version = "0.35.2"
+version = "0.35.3"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Why

`command --files a.txt --files b.txt` silently dropped `a.txt` — the keyword-parse loop in `get_cmd_args` stores into a plain dict, so a repeated flag overwrote the previous value. Downstream (the `obi` CLI), `obi api -q a=1 -q b=2` sent only `b=2`, producing silently-unfiltered API queries.

## What

- `get_cmd_args`: when a flag repeats and the option is list-typed, the new value is appended to the previous one (same encoding as the documented space-separated form). Repeated scalar flags keep the existing last-wins behavior; booleans unchanged.
- Two new `test_get_cmd_args` cases: `repeated_list_flag_accumulates`, `repeated_scalar_flag_keeps_last`.
- `docs/options.md` List Types section documents the repeated-flag form.

144 tests pass; ruff clean; pyright errors are pre-existing (example-file imports).