### PR TITLE
fix: boolean global option after the command swallows the next argument

### DIFF
--- a/piou/utils.py
+++ b/piou/utils.py
@@ -631,6 +631,8 @@ def parse_input_args(
         if not global_option_names:
             return "__main__", [], list(args)
 
+    _bool_opts = global_bool_option_names or set()
+
     # Find the command
     cmd = None
     cmd_index = None
@@ -644,7 +646,6 @@ def parse_input_args(
     if cmd is None and "__main__" in commands:
         if not global_option_names:
             return "__main__", [], list(args)
-        _bool_opts = global_bool_option_names or set()
         global_options: list[str] = []
         cmd_options: list[str] = []
         i = 0
@@ -699,8 +700,13 @@ def parse_input_args(
         arg = after_cmd[i]
         if arg in global_option_names:
             global_options.append(arg)
-            # Check if next arg is a value for this option
-            if i + 1 < len(after_cmd) and not after_cmd[i + 1].startswith("-") and after_cmd[i + 1] not in commands:
+            # Check if next arg is a value for this option (bool flags take no value)
+            if (
+                arg not in _bool_opts
+                and i + 1 < len(after_cmd)
+                and not after_cmd[i + 1].startswith("-")
+                and after_cmd[i + 1] not in commands
+            ):
                 i += 1
                 global_options.append(after_cmd[i])
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -745,7 +745,15 @@ def test_reuse_option():
     assert called
 
 
-def test_run_command_pass_global_args():
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(("-q", "foo", "1"), id="before_command"),
+        pytest.param(("foo", "1", "-q"), id="after_command_args"),
+        pytest.param(("foo", "-q", "1"), id="between_command_and_positional"),
+    ],
+)
+def test_run_command_pass_global_args(args):
     from piou import Cli, Option
 
     called, processor_called = False, False
@@ -775,14 +783,7 @@ def test_run_command_pass_global_args():
         assert quiet is True, "Quiet should be True"
         assert verbose is False, "Verbose should be False"
 
-    #
-    cli._group.run_with_args("-q", "foo", "1")
-    assert called
-    assert processor_called
-
-    called, processor_called = False, False
-    # Also works when passing the global option to the command
-    cli._group.run_with_args("foo", "1", "-q")
+    cli._group.run_with_args(*args)
     assert called
     assert processor_called
 


### PR DESCRIPTION
## Description

**fix**: a boolean global option (e.g. from `cli.add_option` or a processor) placed between the command and its arguments consumed the next argument as its value.

```
$ python -m examples.simple foo 1 -b baz --verbose   # OK
$ python -m examples.simple foo --verbose 1 -b baz   # Expected 1 positional arguments but got 0
```

The after-command loop in `parse_input_args` never checked `global_bool_option_names` (unlike the `__main__` branch), so bool flags were treated as value-taking. Added the same guard and parametrized `test_run_command_pass_global_args` over the three flag positions (the new `between_command_and_positional` case fails without the fix).